### PR TITLE
Improve error handling and tests

### DIFF
--- a/dictionary_handler.py
+++ b/dictionary_handler.py
@@ -1,10 +1,30 @@
 """Minimal dictionary handling utilities."""
 
+import os
+
 DICTIONARY_WORDS = set()
 
 
 def load_dictionary(path: str) -> None:
-    """Load words from the given file into DICTIONARY_WORDS."""
+    """Load words from the given file into ``DICTIONARY_WORDS``.
+
+    Parameters
+    ----------
+    path:
+        Path to the dictionary file.
+
+    Raises
+    ------
+    ValueError
+        If ``path`` is not a non-empty string.
+    FileNotFoundError
+        If ``path`` does not point to an existing file.
+    """
+    if not isinstance(path, str) or not path:
+        raise ValueError("path must be a non-empty string")
+    if not os.path.isfile(path):
+        raise FileNotFoundError(path)
+
     global DICTIONARY_WORDS
     with open(path, "r", encoding="utf-8") as f:
         DICTIONARY_WORDS = {w.strip().lower() for w in f if w.strip()}

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,38 @@
+import os
+import pytest
+
+from dictionary_handler import load_dictionary
+from tiles import PlayerRack, create_tile_bag
+
+
+def test_load_dictionary_invalid_type():
+    with pytest.raises(ValueError):
+        load_dictionary(None)
+
+
+def test_load_dictionary_missing_file(tmp_path):
+    missing = tmp_path / "nope.txt"
+    with pytest.raises(FileNotFoundError):
+        load_dictionary(str(missing))
+
+
+def test_player_rack_invalid_size():
+    with pytest.raises(ValueError):
+        PlayerRack([], rack_size=0)
+
+
+def test_player_rack_invalid_bag_type():
+    with pytest.raises(TypeError):
+        PlayerRack("notalist")
+
+
+def test_player_rack_add_tile_invalid():
+    rack = PlayerRack(create_tile_bag())
+    with pytest.raises(TypeError):
+        rack.add_tile("A")
+
+
+def test_player_rack_remove_tile_invalid_arg():
+    rack = PlayerRack(create_tile_bag())
+    with pytest.raises(TypeError):
+        rack.remove_tile(42)

--- a/tiles.py
+++ b/tiles.py
@@ -77,6 +77,11 @@ class PlayerRack:
     __slots__ = ('rack_size', 'tile_bag', 'tiles')
 
     def __init__(self, tile_bag, rack_size=7):
+        if rack_size <= 0:
+            raise ValueError("rack_size must be positive")
+        if tile_bag is not None and not isinstance(tile_bag, list):
+            raise TypeError("tile_bag must be a list or None")
+
         self.rack_size = rack_size
         self.tile_bag = tile_bag  # Reference to the game's tile bag
         self.tiles = []
@@ -126,7 +131,9 @@ class PlayerRack:
                 # This part might need more robust handling for blank tiles specifically
                 # if their 'letter' field is changed upon placement.
                 # For now, we assume the tile object passed is from the rack.
-                pass # Tile not found by object, would have been caught by char search
+                pass  # Tile not found by object, would have been caught by char search
+        else:
+            raise TypeError("argument must be a letter (str) or tile dictionary")
 
         return tile_to_remove # Tile not found or already removed
 
@@ -134,6 +141,8 @@ class PlayerRack:
         """Adds a tile to the rack (e.g., if exchanging or move undone)."""
         if tile is None:
             return
+        if not isinstance(tile, dict) or 'letter' not in tile:
+            raise TypeError("tile must be a dictionary with a 'letter' key")
         if len(self.tiles) < self.rack_size:
             self.tiles.append(tile)
 


### PR DESCRIPTION
## Summary
- validate path when loading dictionary
- validate inputs when constructing `PlayerRack` and manipulating tiles
- add tests ensuring invalid inputs raise exceptions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fa3f8ac50832599de20b4f226252e