### PR TITLE
Externalize config values

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,24 @@
+import os
+
+# Paths and URLs
+CHROMEDRIVER_PATH = os.environ.get("CHROMEDRIVER_PATH", "chromedriver")
+LITERAKI_URL = os.environ.get("LITERAKI_URL", "https://www.kurnik.pl/literaki/")
+DICTIONARY_PATH = os.environ.get("DICTIONARY_PATH", "dictionary.txt")
+
+# Timing and refresh
+REFRESH_INTERVAL = float(os.environ.get("REFRESH_INTERVAL", "1.0"))
+INITIAL_WAIT_TIME = float(os.environ.get("INITIAL_WAIT_TIME", "5.0"))
+
+# OCR and detection settings
+OCR_GPU = os.environ.get("OCR_GPU", "True").lower() in ("1", "true", "yes")
+OCR_CONFIDENCE_THRESHOLD = float(os.environ.get("OCR_CONFIDENCE_THRESHOLD", "0.3"))
+OCR_DEBUG_DIR = os.environ.get("OCR_DEBUG_DIR", "ocr_debug")
+
+# Screenshot and cropping
+SCREENSHOT_DIR = os.environ.get("SCREENSHOT_DIR", "screenshots")
+BOARD_CROP_COORDS = tuple(map(int, os.environ.get("BOARD_CROP_COORDS", "528,146,1080,702").split(',')))
+RACK_CROP_COORDS = tuple(map(int, os.environ.get("RACK_CROP_COORDS", "1184,286,1491,328").split(',')))
+
+# Detection thresholds
+MIN_RED_CONTOUR_AREA = int(os.environ.get("MIN_RED_CONTOUR_AREA", "100"))
+MIN_BOARD_CONFIDENCE = int(os.environ.get("MIN_BOARD_CONFIDENCE", "75"))

--- a/ocr_utils.py
+++ b/ocr_utils.py
@@ -2,6 +2,7 @@ import os
 from datetime import datetime
 import cv2
 import numpy as np
+import config
 
 # Mapping of OCR characters to valid Literaki letters including common mistakes
 CHAR_MAPPING = {
@@ -16,8 +17,11 @@ CHAR_MAPPING = {
 }
 
 
-def preprocess_image(image_bgr, prefix, debug_dir="ocr_debug"):
+def preprocess_image(image_bgr, prefix, debug_dir=None):
     """Apply common preprocessing steps to improve OCR accuracy."""
+    if debug_dir is None:
+        debug_dir = config.OCR_DEBUG_DIR
+
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     if not os.path.exists(debug_dir):
         os.makedirs(debug_dir)

--- a/test_setup.py
+++ b/test_setup.py
@@ -7,6 +7,7 @@ Run this before using the main helper.py to ensure everything is working correct
 import sys
 import os
 import traceback
+import config
 from typing import List, Tuple
 
 def test_imports() -> Tuple[bool, List[str]]:
@@ -92,11 +93,12 @@ def test_project_files() -> bool:
             print(f"  [FAIL] {file} missing")
             all_exist = False
     
-    # Check for dictionary.txt (will be created if missing)
-    if os.path.exists("dictionary.txt"):
-        print("  [OK] dictionary.txt found")
+    # Check for dictionary file (will be created if missing)
+    from config import DICTIONARY_PATH
+    if os.path.exists(DICTIONARY_PATH):
+        print(f"  [OK] {DICTIONARY_PATH} found")
     else:
-        print("  [WARN] dictionary.txt missing (will be created automatically)")
+        print(f"  [WARN] {DICTIONARY_PATH} missing (will be created automatically)")
     
     return all_exist
 


### PR DESCRIPTION
## Summary
- add `config.py` with environment variable driven options
- use `config.py` in `helper.py`, `ocr_utils.py` and `test_setup.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fa40d40688325a69e9e8a20f4ff06